### PR TITLE
add send() that supports byte[] representation of json object

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ public class LogzioSenderExample {
 
 
 ### Release notes
+ - 1.0.18
+   - add byte[] send option
  - 1.0.17
    - add support for log count limit option 
  - 1.0.16

--- a/logzio-sender/src/main/java/io/logz/sender/HttpsSyncSender.java
+++ b/logzio-sender/src/main/java/io/logz/sender/HttpsSyncSender.java
@@ -9,12 +9,15 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
 public class HttpsSyncSender {
     private final HttpsRequestConfiguration configuration;
     private final SenderStatusReporter reporter;
+    private static final byte[] NEW_LINE_AS_UTF8_BYTE_ARRAY = "\n".getBytes(StandardCharsets.UTF_8);
+    private static final int NEW_LINE_AS_UTF8_BYTE_ARRAY_SIZE = NEW_LINE_AS_UTF8_BYTE_ARRAY.length;
 
 
     public HttpsSyncSender(HttpsRequestConfiguration configuration, SenderStatusReporter reporter) {
@@ -39,10 +42,11 @@ public class HttpsSyncSender {
     }
 
     private byte[] toNewLineSeparatedByteArray(List<FormattedLogMessage> messages) {
-        try (ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream(sizeInBytes(messages));
+        try (ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream(sizeInBytes(messages) + NEW_LINE_AS_UTF8_BYTE_ARRAY_SIZE * messages.size());
              OutputStream os = configuration.isCompressRequests() ? new GZIPOutputStream(byteOutputStream) : byteOutputStream) {
             for (FormattedLogMessage currMessage : messages) {
                 os.write(currMessage.getMessage());
+                os.write(NEW_LINE_AS_UTF8_BYTE_ARRAY);
             }
             // Need close before return for gzip compression, The stream only knows to compress and write the last bytes when you tell it to close
             os.close();

--- a/logzio-sender/src/main/java/io/logz/sender/LogzioSender.java
+++ b/logzio-sender/src/main/java/io/logz/sender/LogzioSender.java
@@ -55,8 +55,20 @@ public class LogzioSender  {
 
     /**
      * Change constructor to a builder pattern
-     *
      * @deprecated use {@link #builder()} instead.
+     * @param logzioToken your logz.io token
+     * @param logzioType your logz.io log type
+     * @param drainTimeout how long between sending a new bulk of logs
+     * @param fsPercentThreshold FS percent threshold for the queue that uses the disk
+     * @param queueDir queue File
+     * @param logzioUrl your logz.io url
+     * @param socketTimeout socket timeout
+     * @param connectTimeout connect timeout
+     * @param debug set true if debug prints are needed
+     * @param reporter reporter for logging messages
+     * @param tasksExecutor thread pool for the different scheduled tasks
+     * @param gcPersistedQueueFilesIntervalSeconds interval for cleaning shipped logs from the disk
+     * @param compressRequests set true if https send compressed payload
      */
     @Deprecated
     public static synchronized LogzioSender getOrCreateSenderByType(String logzioToken, String logzioType,
@@ -96,6 +108,18 @@ public class LogzioSender  {
      * Change constructor to a builder pattern
      *
      * @deprecated use {@link #builder()} instead.
+     * @param logzioToken your logz.io token
+     * @param logzioType your logz.io log type
+     * @param drainTimeout how long between sending a new bulk of logs
+     * @param fsPercentThreshold FS percent threshold for the queue that uses the disk
+     * @param queueDir queue File
+     * @param logzioUrl your logz.io url
+     * @param socketTimeout socket timeout
+     * @param connectTimeout connect timeout
+     * @param debug set true if debug prints are needed
+     * @param reporter reporter for logging messages
+     * @param tasksExecutor thread pool for the different scheduled tasks
+     * @param gcPersistedQueueFilesIntervalSeconds interval for cleaning shipped logs from the disk
      */
     @Deprecated
     public static synchronized LogzioSender getOrCreateSenderByType(String logzioToken, String logzioType, int drainTimeout, int fsPercentThreshold, File queueDir,
@@ -180,7 +204,7 @@ public class LogzioSender  {
 
     /**
      * Send byte array to Logz.io
-     * @implNote This method is not the recommended method to use
+     * This method is not the recommended method to use
      * since it is up to the user to supply with a valid UTF8 json byte array
      * representation. In any case the byte[] is not valid, the logs will not be sent.
      * @param jsonStringAsUTF8ByteArray UTF8 byte array representation of a valid json object.

--- a/logzio-sender/src/main/java/io/logz/sender/LogzioSender.java
+++ b/logzio-sender/src/main/java/io/logz/sender/LogzioSender.java
@@ -25,7 +25,6 @@ public class LogzioSender  {
 
     private static final Map<String, LogzioSender> logzioSenderInstances = new HashMap<>();
     private static final int FINAL_DRAIN_TIMEOUT_SEC = 20;
-    private static final byte[] NEW_LINE_AS_UTF8_BYTE_ARRAY = "\n".getBytes(StandardCharsets.UTF_8);
 
     private final LogsQueue logsQueue;
     private final int drainTimeout;
@@ -176,24 +175,19 @@ public class LogzioSender  {
 
     public void send(JsonObject jsonMessage) {
         // Return the json, while separating lines with \n
-        logsQueue.enqueue((jsonMessage+ "\n").getBytes(StandardCharsets.UTF_8));
+        logsQueue.enqueue(jsonMessage.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     /**
      * Send byte array to Logz.io
-     * @implNote This method is not recommended to use since it is up to the user to supply with a valid UTF8 json byte array
+     * @implNote This method is not the recommended method to use
+     * since it is up to the user to supply with a valid UTF8 json byte array
      * representation. In any case the byte[] is not valid, the logs will not be sent.
      * @param jsonStringAsUTF8ByteArray UTF8 byte array representation of a valid json object.
      */
     public void send(byte[] jsonStringAsUTF8ByteArray) {
         // Return the byte[], while separating lines with \n
-        try(ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream(jsonStringAsUTF8ByteArray.length + 1)) {
-            byteOutputStream.write(jsonStringAsUTF8ByteArray);
-            byteOutputStream.write(NEW_LINE_AS_UTF8_BYTE_ARRAY);
-            logsQueue.enqueue(byteOutputStream.toByteArray());
-        } catch (IOException e) {
-            reporter.error("Fail to write jsonStringAsUTF8ByteArray, dropping log", e);
-        }
+        logsQueue.enqueue(jsonStringAsUTF8ByteArray);
     }
 
     private List<FormattedLogMessage> dequeueUpToMaxBatchSize() {

--- a/logzio-sender/src/test/java/io/logz/sender/LogzioSenderTest.java
+++ b/logzio-sender/src/test/java/io/logz/sender/LogzioSenderTest.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -102,6 +103,29 @@ public abstract class LogzioSenderTest {
 
         testSender.send( createJsonMessage(loggerName, message1));
         testSender.send( createJsonMessage(loggerName, message2));
+        sleepSeconds(drainTimeout  *3);
+
+        mockListener.assertNumberOfReceivedMsgs(2);
+        mockListener.assertLogReceivedIs(message1, token, type, loggerName, LOGLEVEL);
+        mockListener.assertLogReceivedIs(message2, token, type, loggerName, LOGLEVEL);
+    }
+
+    @Test
+    public void simpleByteArrayAppending() throws Exception {
+        String token = "aBcDeFgHiJkLmNoPqRsT";
+        String type = random(8);
+        String loggerName = "simpleByteArrayAppending";
+        int drainTimeout = 2;
+
+        String message1 = "Testing.." + random(5);
+        String message2 = "Warning test.." + random(5);
+
+        LogzioSender.Builder testSenderBuilder = getLogzioSenderBuilder(token, type, drainTimeout,
+                10 * 1000, 10 * 1000, tasks,false);
+        LogzioSender testSender = createLogzioSender(testSenderBuilder);
+
+        testSender.send( createJsonMessage(loggerName, message1).toString().getBytes(StandardCharsets.UTF_8));
+        testSender.send( createJsonMessage(loggerName, message2).toString().getBytes(StandardCharsets.UTF_8));
         sleepSeconds(drainTimeout  *3);
 
         mockListener.assertNumberOfReceivedMsgs(2);


### PR DESCRIPTION
Since this is a low-level library that is used primarily from our java appenders we will allow the send method to accept byte[].