### PR TITLE
Malformed lines bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 
 cache:
   directories:

--- a/logzio-sender/src/main/java/io/logz/sender/HttpsSyncSender.java
+++ b/logzio-sender/src/main/java/io/logz/sender/HttpsSyncSender.java
@@ -57,7 +57,7 @@ public class HttpsSyncSender {
             int currentRetrySleep = configuration.getInitialWaitBeforeRetryMS();
 
             for (int currTry = 1; currTry <= configuration.getMaxRetriesAttempts(); currTry++) {
-                boolean shouldRetry = true;
+                boolean retry = true;
                 int responseCode = 0;
                 String responseMessage = "";
                 IOException savedException = null;
@@ -66,13 +66,13 @@ public class HttpsSyncSender {
                     HttpURLConnection conn = sendRequest(payload);
                     responseCode = conn.getResponseCode();
                     responseMessage = conn.getResponseMessage();
-                    shouldRetry = shouldRetry(payload, responseCode, responseMessage, conn);
+                    retry = shouldRetry(payload, responseCode, responseMessage, conn);
                 } catch (IOException e) {
                     savedException = e;
                     reporter.error("Got IO exception - " + e.getMessage());
                 }
 
-                if (shouldRetry) {
+                if (retry) {
                     currentRetrySleep = tryBackoff(currentRetrySleep, currTry, responseCode, responseMessage, savedException);
                 } else {
                     break;
@@ -100,7 +100,7 @@ public class HttpsSyncSender {
     }
 
     private boolean shouldRetry(byte[] payload, int responseCode, String responseMessage, HttpURLConnection conn) {
-        boolean shouldRetry = false;
+        boolean retry = false;
         if (responseCode == HttpURLConnection.HTTP_BAD_REQUEST) {
             readResponse(conn);
         }
@@ -110,9 +110,9 @@ public class HttpsSyncSender {
         else if (responseCode == HttpURLConnection.HTTP_OK) {
             reporter.info("Successfully sent bulk to logz.io, size: " + payload.length);
         } else {
-            shouldRetry = true;
+            retry = true;
         }
-        return shouldRetry;
+        return retry;
     }
 
     private void readResponse(HttpURLConnection conn) {

--- a/logzio-sender/src/main/java/io/logz/sender/LogzioSender.java
+++ b/logzio-sender/src/main/java/io/logz/sender/LogzioSender.java
@@ -166,7 +166,6 @@ public class LogzioSender  {
                 List<FormattedLogMessage> logsList = dequeueUpToMaxBatchSize();
                 try {
                     httpsSyncSender.sendToLogzio(logsList);
-
                 } catch (LogzioServerErrorException e) {
                     debug("Could not send log to logz.io: ", e);
                     debug("Will retry in the next interval");

--- a/logzio-sender/src/test/java/io/logz/sender/LogzioSenderTest.java
+++ b/logzio-sender/src/test/java/io/logz/sender/LogzioSenderTest.java
@@ -11,8 +11,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;


### PR DESCRIPTION
Fixing bug:
When we receive a bad request from the listener we try to send the bulk again. This creates duplicate logs in case we have valid JSON objects in that bulk that the listener processed properly(resend of valid json too).