### PR TITLE
[Release] version `2.3.0`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,14 +15,14 @@ jobs:
         with:
           java-version: 11
           distribution: 'zulu'
-          server-id: ossrh-nexus
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
       - name: Publish to the Maven Central Repository
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: mvn deploy --batch-mode -D skipTests --activate-profiles release --no-transfer-progress

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - name: Get the code
         uses: actions/checkout@v4
-      - name: Setup Java 11
+      - name: Setup Java 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
           server-id: central
           server-username: MAVEN_USERNAME

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,10 +8,10 @@ jobs:
     steps:
       - name: Get the code
         uses: actions/checkout@v4
-      - name: Setup Java 11
+      - name: Setup Java 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
       - name: Test with Maven
         run: mvn test

--- a/README.md
+++ b/README.md
@@ -136,10 +136,11 @@ public class LogzioSenderExample {
 
 
 ## Release notes
-- 2.3.0
+- 3.0.0
     - Upgraded `logzio-sender-test` to use Jetty 12 with Servlet EE9 environment.
-    - Upgrade dependencies
-    - Migrated artifact publishing from OSSRH to Central Portal
+    - Dropped support for Java 11 — Java 17 or higher is now required.
+    - Upgrade dependencies.
+    - Migrated artifact publishing from OSSRH to Central Portal.
  - 2.2.0
    - Add `WithOpentelemetryContext` parameter to add `trace_id`, `span_id`, `service_name` fields to logs when opentelemetry context is available.
  - 2.1.0

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ public class LogzioSenderExample {
 
 
 ## Release notes
+- 2.3.0
+    - Upgraded `logzio-sender-test` to use Jetty 12 with Servlet EE9 environment.
+    - Upgrade dependencies
+    - Migrated artifact publishing from OSSRH to Central Portal
  - 2.2.0
    - Add `WithOpentelemetryContext` parameter to add `trace_id`, `span_id`, `service_name` fields to logs when opentelemetry context is available.
  - 2.1.0

--- a/README.md
+++ b/README.md
@@ -136,11 +136,9 @@ public class LogzioSenderExample {
 
 
 ## Release notes
-- 3.0.0
+- 2.3.0
     - Upgraded `logzio-sender-test` to use Jetty 12 with Servlet EE9 environment.
-    - Dropped support for Java 11 — Java 17 or higher is now required.
     - Upgrade dependencies.
-    - Migrated artifact publishing from OSSRH to Central Portal.
  - 2.2.0
    - Add `WithOpentelemetryContext` parameter to add `trace_id`, `span_id`, `service_name` fields to logs when opentelemetry context is available.
  - 2.1.0

--- a/logzio-sender-test/pom.xml
+++ b/logzio-sender-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>logzio-java-sender</artifactId>
         <groupId>io.logz.sender</groupId>
-        <version>3.0.0</version>
+        <version>2.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/logzio-sender-test/pom.xml
+++ b/logzio-sender-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>logzio-java-sender</artifactId>
         <groupId>io.logz.sender</groupId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -60,6 +60,14 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.ee9</groupId>
+            <artifactId>jetty-ee9-servlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/logzio-sender-test/pom.xml
+++ b/logzio-sender-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>logzio-java-sender</artifactId>
         <groupId>io.logz.sender</groupId>
-        <version>2.3.0</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/logzio-sender/pom.xml
+++ b/logzio-sender/pom.xml
@@ -5,16 +5,16 @@
     <parent>
         <artifactId>logzio-java-sender</artifactId>
         <groupId>io.logz.sender</groupId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>logzio-sender</artifactId>
     <repositories>
         <repository>
-            <id>ikasaneip-snapshots</id>
-            <name>Ikasan EIP Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </repository>
     </repositories>
     <build>
@@ -22,7 +22,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -142,7 +142,16 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.eclipse.jetty.ee9</groupId>
+            <artifactId>jetty-ee9-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/logzio-sender/pom.xml
+++ b/logzio-sender/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>logzio-java-sender</artifactId>
         <groupId>io.logz.sender</groupId>
-        <version>3.0.0</version>
+        <version>2.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/logzio-sender/pom.xml
+++ b/logzio-sender/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>logzio-java-sender</artifactId>
         <groupId>io.logz.sender</groupId>
-        <version>2.3.0</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.logz.sender</groupId>
     <artifactId>logzio-java-sender</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.0</version>
+    <version>2.3.0</version>
 
     <name>Logz.io Logs Sender</name>
     <description>Send your log messages to your logz.io account in an encrypted, non-blocking manner.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.logz.sender</groupId>
     <artifactId>logzio-java-sender</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.0</version>
+    <version>2.3.0</version>
 
     <name>Logz.io Logs Sender</name>
     <description>Send your log messages to your logz.io account in an encrypted, non-blocking manner.</description>
@@ -37,9 +37,9 @@
 
     <repositories>
         <repository>
-            <id>ikasaneip-snapshots</id>
-            <name>Ikasan EIP Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </repository>
     </repositories>
     <modules>
@@ -49,9 +49,9 @@
 
     <distributionManagement>
         <repository>
-            <id>ossrh-nexus</id>
-            <name>Central Repository OSSRH</name>
-            <url>https://oss.sonatype.org/</url>
+            <id>central</id>
+            <name>Central Portal Repository</name>
+            <url>https://central.sonatype.com/</url>
         </repository>
     </distributionManagement>
 
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.10.0</version>
+                <version>3.11.2</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.2.7</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -94,20 +94,20 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.7.0</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh-nexus</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.5.3</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>
@@ -166,7 +166,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
-                <version>9.4.56.v20240826</version>
+                <version>12.0.21</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -182,6 +182,16 @@
                 <groupId>org.ikasan</groupId>
                 <artifactId>bigqueue</artifactId>
                 <version>1.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.ee9</groupId>
+                <artifactId>jetty-ee9-servlet</artifactId>
+                <version>12.0.21</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>6.1.0</version>
             </dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.logz.sender</groupId>
     <artifactId>logzio-java-sender</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.0</version>
+    <version>3.0.0</version>
 
     <name>Logz.io Logs Sender</name>
     <description>Send your log messages to your logz.io account in an encrypted, non-blocking manner.</description>


### PR DESCRIPTION
## Description 

this pr resolves #64 closes #90 closes #91 closes #93 closes #94 closes #95 closes #97

- Change publishing from OSSRH to Central Portal
- Upgrade dependencies
- Upgrade `logzio-sender-test` to use Jetty 12 with Servlet EE9 environment
- Upgrade CI to use Java 17 due to Jetty 12 dropping support of Java 11 (not breaking change because it's only the test scope)
- Update changelog in readme

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
