### PR TITLE
test: fix Jetty 12 RuntimeIOException deprecation and Windows POSIX c…

### DIFF
--- a/logzio-sender-test/src/main/java/io/logz/test/MockLogzioBulkListener.java
+++ b/logzio-sender-test/src/main/java/io/logz/test/MockLogzioBulkListener.java
@@ -9,7 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee9.servlet.ServletHolder;
-import org.eclipse.jetty.io.RuntimeIOException;
+import java.io.UncheckedIOException;
 import org.eclipse.jetty.server.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -146,7 +146,7 @@ public class MockLogzioBulkListener implements Closeable {
             }
             attempts++;
             if (attempts > 10) {
-                throw new RuntimeIOException("Failed to start after multiple attempts");
+                throw new UncheckedIOException(new IOException("Failed to start after multiple attempts"));
             }
         }
         logger.info("Started listening on {}:{} ({})", host, port, this);
@@ -169,7 +169,7 @@ public class MockLogzioBulkListener implements Closeable {
             }
             attempts++;
             if (attempts > 10) {
-                throw new RuntimeIOException("Failed to stop after multiple attempts");
+                throw new UncheckedIOException(new IOException("Failed to stop after multiple attempts"));
             }
         }
         logger.info("Stopped listening on {}:{} ({})", host, port, this);

--- a/logzio-sender-test/src/main/java/io/logz/test/TestEnvironment.java
+++ b/logzio-sender-test/src/main/java/io/logz/test/TestEnvironment.java
@@ -40,11 +40,17 @@ public class TestEnvironment {
                 +buildDirSubString+" in the following classpath: "+classPath));
 
         try {
-            FileAttribute<Set<PosixFilePermission>> fileAttributes = PosixFilePermissions.asFileAttribute(EnumSet
-                    .of(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE,
-                            GROUP_READ, GROUP_EXECUTE, GROUP_WRITE,
-                            OTHERS_EXECUTE, OTHERS_READ, OTHERS_WRITE));
-            return Files.createTempDirectory(buildDir.toPath(), "", fileAttributes).toFile();
+            boolean isPosixSupported = java.nio.file.FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+
+            if (isPosixSupported) {
+                FileAttribute<Set<PosixFilePermission>> fileAttributes = PosixFilePermissions.asFileAttribute(EnumSet
+                        .of(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE,
+                                GROUP_READ, GROUP_EXECUTE, GROUP_WRITE,
+                                OTHERS_EXECUTE, OTHERS_READ, OTHERS_WRITE));
+                return Files.createTempDirectory(buildDir.toPath(), "", fileAttributes).toFile();
+            } else {
+                return Files.createTempDirectory(buildDir.toPath(), "").toFile();
+            }
         } catch (IOException e) {
             throw new RuntimeException("Failed creating temp directory in "+buildDir.getAbsolutePath(), e);
         }


### PR DESCRIPTION
## Description 

This PR fixes the local test environment setup to allow running tests on Windows machines, and replaces a deprecated Jetty API.

**Previous behavior:** 

1. `TestEnvironment.createTempDirectory()` threw an `UnsupportedOperationException` on Windows due to hardcoded POSIX file permissions (NTFS does not support them).

2. `MockLogzioBulkListener` used `org.eclipse.jetty.io.RuntimeIOException` which is deprecated for removal in Jetty 12.

**New behavior:**

1. Checks if `posix` is supported by the underlying file system (`FileSystems.getDefault().supportedFileAttributeViews()`) before applying POSIX attributes. On Windows, it falls back to standard directory creation, while maintaining original behavior on Linux/Unix/CI environments.

2. Uses the standard `java.io.UncheckedIOException` instead of the deprecated Jetty class.


## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
